### PR TITLE
Update to Appdaemon 4.5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ This means that if you're running via the VSCode addon directly on HomeAssistant
 
 You may want either:
 - To disable VSCode auto-save in its settings (only manually save with Ctrl+S)
-- To disable appdaemon auto-reload by setting `production: true` in `appdaemon.yaml`, and reload the addon when you want to test new app versions (slower)
+- To disable appdaemon auto-reload by setting `production_mode: true` in `appdaemon.yaml`, and reload the addon when you want to test new app versions (slower)
 
 Note that in any case, you may need to reload the appdaemon addon after editing files other than a single-app file (in particular after refreshing `hapt.py`).
 
@@ -128,19 +128,9 @@ appdaemon:
 Then we will register our first app.
 Update your `apps.yaml` like so:
 ```yaml
-homeassistant_python_typer_helpers:
-  module: homeassistant_python_typer_helpers
-  global: true
-hapt:
-  module: hapt
-  global: true
-  dependencies: homeassistant_python_typer_helpers
-
 my_first_sensor_light:
   module: my_first_sensor_light
   class: HallwaySensorLights
-  dependencies:
-    - hapt
 ```
 
 More details on the `apps.yaml` structure and options [in the AppDaemon documentation](https://appdaemon.readthedocs.io/en/latest/APPGUIDE.html#configuration-of-apps).

--- a/README.md
+++ b/README.md
@@ -191,15 +191,7 @@ Such insidious bugs are prevented by this repeatable read feature, provided in t
 
 ### What to be careful about
 
-The downside of this is that for correctness, it's required to manually clear the state cache (`self.ha.hapt.clear_caches()`) **if using native appdaemon callbacks**. [Example](https://github.com/Ten0/homeassistant_python_typer/blob/be354da32c4a7c6f0911058943fc40c6fb860cd4/examples/thermostat.py#L75-L78).
-
-This is important because if forgotten, one may be reading the previous entities states when handling a new event.
-
-Typed listen_state APIs provided by `homeassistant_python_typer` already clear the caches as they receive an event, so they don't have this quirk.
-
-Despite this downside, it is estimated to be a better compromise than not having this feature because assuming that you ultimately want your automations to always work, it easier to not forget this than to consider all potential subtle races such as the one described above.
-
-Ultimately this project will probably either find a way to identify event handling jumps automatically to clear caches automatically, or provide overlays for more appdaemon APIs that would also perform implicit cache clearing where appropriate.
+Leave AppDaemon's threading options to their default values: this feature is incompatible with disabling [app pinning](https://appdaemon.readthedocs.io/en/4.5.0/APPGUIDE.html#appdaemon-and-threading) as races between callbacks would break repeatable read guarantees.
 
 # 💬 Community & Feedback
 

--- a/examples/sensor_lights.py
+++ b/examples/sensor_lights.py
@@ -26,7 +26,6 @@ class HallwaySensorLights(hass.Hass):
         self.log("Initialized HallwaySensorLights")
 
     def timer_trigger(self, cb_args: dict[str, object]):
-        self.ha.hapt.clear_caches()  # Necessary with native appdaemon triggers
         self.timer = None
         self.set_light()
 

--- a/examples/sensor_lights_night_mode.py
+++ b/examples/sensor_lights_night_mode.py
@@ -36,12 +36,10 @@ class HallwaySensorLights(hass.Hass):
         self.log("Initialized HallwaySensorLights")
 
     def timer_trigger(self, cb_args: dict[str, object]):
-        self.ha.hapt.clear_caches()  # Necessary with native appdaemon triggers
         self.timer = None
         self.set_light()
 
     def check_light_trigger(self, cb_args: dict[str, object]):
-        self.ha.hapt.clear_caches()  # Necessary with native appdaemon triggers
         self.set_light()
 
     def check_sensor(self):

--- a/examples/thermostat.py
+++ b/examples/thermostat.py
@@ -75,7 +75,6 @@ class ThermostatControl(hass.Hass):
 
     def appdaemon_native_trigger(self, cb_args: dict[str, object]):
         "Useful for direct AppDaemon triggers (e.g. run_daily or run_in)"
-        self.ha.hapt.clear_caches()  # Necessary with native appdaemon triggers
         self.check()
 
     def check(self):

--- a/homeassistant_python_typer_helpers.py
+++ b/homeassistant_python_typer_helpers.py
@@ -10,7 +10,7 @@ from typing import (
     assert_never,
 )
 from appdaemon.adbase import ADBase
-from appdaemon.utils import sync_wrapper
+from appdaemon.utils import sync_decorator
 
 OnOff: TypeAlias = Literal["on", "off"]
 
@@ -34,7 +34,7 @@ class HaptSharedState:
         self.state_cache = {}
         self.full_cache = {}
 
-        # Unfortunately we need those for the sync_wrapper to work
+        # Unfortunately we need those for the sync_decorator to work
         self.name = self.ad.name
         "Name of the appdaemon app that this Entity is linked to - not a property of the entity itself"
         self.AD = self.ad.AD
@@ -48,7 +48,7 @@ class HaptSharedState:
         self.state_cache.clear()
         self.full_cache.clear()
 
-    @sync_wrapper
+    @sync_decorator
     async def call(
         self,
         domain: str,
@@ -96,7 +96,7 @@ class Entity:
         self.entity_id = entity_id
         self.namespace = namespace or self.hapt.ad.namespace
 
-        # Unfortunately we need those for the sync_wrapper to work
+        # Unfortunately we need those for the sync_decorator to work
         self.name = self.hapt.ad.name
         "Name of the appdaemon app that this Entity is linked to - not a property of the entity itself"
         self.AD = self.hapt.ad.AD
@@ -124,7 +124,7 @@ class Entity:
 
     # We will eventually try typing this as well but there's no API to know for sure what can be in there this time
     # so for now we'll skip it
-    @sync_wrapper
+    @sync_decorator
     async def query_state(
         self,
         attribute: str | None = None,
@@ -265,7 +265,7 @@ class Entity:
             attribute: str | None,
             old: Any,
             new: Any,
-            cb_args: dict[str, object],
+            **cb_args: dict[str, object],
         ) -> None:
             self.hapt.clear_caches()
             assert self.entity_id == entity
@@ -339,7 +339,7 @@ class Domain:
 
 
 def rgb_color(
-    rgb_array_or_str: list[int] | tuple[int, int, int] | str
+    rgb_array_or_str: list[int] | tuple[int, int, int] | str,
 ) -> tuple[int, int, int]:
     if isinstance(rgb_array_or_str, str):
         # Convert from hashtag hex representation to the RGB tuple

--- a/homeassistant_python_typer_helpers.py
+++ b/homeassistant_python_typer_helpers.py
@@ -229,41 +229,49 @@ class Entity:
         """
         Listen to state changes of the entity.
 
+        The callback can take in extra arguments that are passed to this function, and will be passed as-is.
+        It does not take in entity_id, attribute, etc... as arguments.
+
         Args:
-            callback (Callable): The callback to call when the state changes.
-            attribute (str): The attribute to listen to. If None, the state of the entity is listened to.
-                If `all`, listen for change on any attribute.
+            callback: Function that will be called when the callback gets triggered.
+            new (str | Callable[[Any], bool], optional): If given, the callback will only be invoked if the state of
+                the selected attribute (usually state) matches this value in the new data. The data type is dependent on
+                the specific entity and attribute. Values that look like ints or floats are often actually strings, so
+                be careful when comparing them. The ``self.get_state()`` method is useful for checking the data type of
+                the desired attribute. If ``new`` is a callable (lambda, function, etc), then it will be called with
+                the new state, and the callback will only be invoked if the callable returns ``True``.
+            old (str | Callable[[Any], bool], optional): If given, the callback will only be invoked if the selected
+                attribute (usually state) changed from this value in the new data. The data type is dependent on the
+                specific entity and attribute. Values that look like ints or floats are often actually strings, so be
+                careful when comparing them. The ``self.get_state()`` method is useful for checking the data type of
+                the desired attribute. If ``old`` is a callable (lambda, function, etc), then it will be called with
+                the old state, and the callback will only be invoked if the callable returns ``True``.
+            duration_s (str | int | float | timedelta, optional): If supplied, the callback will not be invoked unless the
+                desired state is maintained for that amount of time. This requires that a specific attribute is
+                specified (or the default of ``state`` is used), and should be used in conjunction with either or both
+                of the ``new`` and ``old`` parameters. When the callback is called, it is supplied with the values of
+                ``entity``, ``attr``, ``old``, and ``new`` that were current at the time the actual event occurred,
+                since the assumption is that none of them have changed in the intervening period.
 
-            new (optional): If ``new`` is supplied as a parameter, callbacks will only be made if the
-                state of the selected attribute (usually state) in the new state match the value
-                of ``new``. The parameter type is defined by the namespace or plugin that is responsible
-                for the entity. If it looks like a float, list, or dictionary, it may actually be a string.
-                If ``new`` is a callable (lambda, function, etc), then it will be invoked with the new state,
-                and if it returns ``True``, it will be considered to match.
-            old (optional): If ``old`` is supplied as a parameter, callbacks will only be made if the
-                state of the selected attribute (usually state) in the old state match the value
-                of ``old``. The same caveats on types for the ``new`` parameter apply to this parameter.
-                If ``old`` is a callable (lambda, function, etc), then it will be invoked with the old state,
-                and if it returns a ``True``, it will be considered to match.
+                If you use ``duration`` when listening for an entire device type rather than a specific entity, or for
+                all state changes, you may get unpredictable results, so it is recommended that this parameter is only
+                used in conjunction with the state of specific entities.
+            attribute (str, optional): Optional name of an attribute to use for the new/old checks. If not specified,
+                the default behavior is to use the value of ``state``. Using the value ``all`` will cause the callback
+                to get triggered for any change in state, and the new/old values used for the callback will be the
+                entire state dict rather than the individual value of an attribute.
+            timeout_s (str | int | float | timedelta, optional): If given, the callback will be automatically removed
+                after that amount of time. If activity for the listened state has occurred that would trigger a
+                duration timer, the duration timer will still be fired even though the callback has been removed.
+            **kwargs: Arbitrary keyword parameters to be provided to the callback function when it is triggered.
 
-            duration_s (int, optional): If ``duration`` is supplied as a parameter, the callback will not
-                fire unless the state listened for is maintained for that number of seconds. This
-                requires that a specific attribute is specified (or the default of ``state`` is used),
-                and should be used in conjunction with the ``old`` or ``new`` parameters, or both. When
-                the callback is called, it is supplied with the values of ``entity``, ``attr``, ``old``,
-                and ``new`` that were current at the time the actual event occurred, since the assumption
-                is that none of them have changed in the intervening period.
+        Note:
+            The ``old`` and ``new`` args can be used singly or together.
 
-                If you use ``duration`` when listening for an entire device type rather than a specific
-                entity, or for all state changes, you may get unpredictable results, so it is recommended
-                that this parameter is only used in conjunction with the state of specific entities.
-
-            timeout_s (int, optional): If ``timeout`` is supplied as a parameter, the callback will be created as normal,
-                 but after ``timeout`` seconds, the callback will be removed. If activity for the listened state has
-                 occurred that would trigger a duration timer, the duration timer will still be fired even though the
-                 callback has been deleted.
-            *args: Additional arguments to pass to the callback.
-            **kwargs: Additional keyword arguments to pass to the callback.
+        Returns:
+            A string that uniquely identifies the callback and can be used to cancel it later if necessary. Since
+            variables created within object methods are local to the function they are created in, it's recommended to
+            store the handles in the app's instance variables, e.g. ``self.handle``.
         """
 
         def callback_wrapper(
@@ -285,22 +293,18 @@ class Entity:
                 self.hapt.state_cache[self.entity_id] = new["state"]
             callback(*args, **kwargs)
 
-        listen_kwargs: dict[str, Any] = {}
-        for kwarg_name, kwarg_value in {
-            "new": new,
-            "old": old,
-            "duration": duration_s,
-            "timeout": timeout_s,
-            "attribute": attribute,
-        }.items():
-            if kwarg_value is not None:
-                listen_kwargs[kwarg_name] = kwarg_value
-        if "duration" in listen_kwargs:
-            # I don't think there's a use-case for anything else...
-            listen_kwargs["immediate"] = True
-
         return self.hapt.adapi.listen_state(
-            callback_wrapper, self.entity_id, **listen_kwargs
+            callback_wrapper,
+            self.entity_id,
+            new=new,
+            old=old,
+            duration=duration_s,
+            timeout=timeout_s,
+            attribute=attribute,
+            immediate=(
+                # I don't think there's a use-case for anything else...
+                (duration_s is not None)
+            ),
         )
 
     def last_changed(self) -> datetime:

--- a/homeassistant_python_typer_helpers.py
+++ b/homeassistant_python_typer_helpers.py
@@ -225,7 +225,7 @@ class Entity:
         timeout_s: int | None = None,
         *args: FunctionArgsGeneric.args,
         **kwargs: FunctionArgsGeneric.kwargs,
-    ) -> None:
+    ) -> str:
         """
         Listen to state changes of the entity.
 
@@ -299,7 +299,9 @@ class Entity:
             # I don't think there's a use-case for anything else...
             listen_kwargs["immediate"] = True
 
-        self.hapt.adapi.listen_state(callback_wrapper, self.entity_id, **listen_kwargs)
+        return self.hapt.adapi.listen_state(
+            callback_wrapper, self.entity_id, **listen_kwargs
+        )
 
     def last_changed(self) -> datetime:
         """

--- a/src/homeassistant_python_typer/__main__.py
+++ b/src/homeassistant_python_typer/__main__.py
@@ -149,7 +149,7 @@ def main():
     class HomeAssistant:
         def __init__(self, ad: ADBase):
             hapt = hapth.HaptSharedState(ad)
-            self.hapt = hapt # So that users can call clear_caches() if writing appdaemon handlers directly
+            self.hapt = hapt
 {domains_init_body}
     """
 


### PR DESCRIPTION
Update doc & helpers to support `appdaemon` 4.5.

Notably this removes that users needed to take special care with regards to repeatable-read caches.