### PR TITLE
Support for installing and running as a package from github url

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,12 +93,28 @@ We need to make appdaemon accessible to the type checker.
 
 Press Ctrl+Shift+C (or call "Create a new terminal" from the command palette) in VSCode to open a terminal.
 
+**Option 1: Using git clone (recommended for development)**
+
 1. Run the following command (You may paste by using Ctrl+Shift+V):
    ```bash
    cd /addon_configs/a0d7b954_appdaemon/ && git clone https://github.com/Ten0/homeassistant_python_typer.git
    ```
 2. Run as described in [How it works](./README.md#-how-it-works) to generate the `apps/hapt.py` and `apps/homeassistant_python_typer_helpers.py` files.
    - **Note that this command will need to be re-run if you have added/removed/updated entities in your Home Assistant and possibly after Home Assistant updates, to make everything known in the `hapt.py` file.**
+
+**Option 2: Using uv (alternative)**
+
+If you have [uv](https://docs.astral.sh/uv/) installed, you can install or run directly from the repository:
+
+- Install in your virtual environment:
+  ```bash
+  uv add git+https://github.com/Ten0/homeassistant_python_typer.git
+  ```
+
+- Or run directly without installing:
+  ```bash
+  uvx git+https://github.com/Ten0/homeassistant_python_typer.git
+  ```
 
 ### Editor configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "homeassistant-python-typer"
+version = "0.1.0"
+description = "Full-fledged typing for your home automation applications. Never see your automations break again."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "requests>=2.32.5",
+]
+
+[project.scripts]
+homeassistant-python-typer = "homeassistant_python_typer.__main__:main"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "homeassistant-python-typer"
+name = "homeassistant_python_typer"
 version = "0.1.0"
 description = "Full-fledged typing for your home automation applications. Never see your automations break again."
 readme = "README.md"
@@ -9,5 +9,5 @@ dependencies = [
 ]
 
 [project.scripts]
-homeassistant-python-typer = "homeassistant_python_typer.__main__:main"
+homeassistant_python_typer = "homeassistant_python_typer.__main__:main"
 


### PR DESCRIPTION
I think this pretty much covers it. You don't need to manage anything pypi.
A sidenote (since I first thought this was already on pypi). You might want to register the name on pypi. Typosquatting is a thing, and LLM's also tends to hallucinate package names :(

This is how it would work now..

```sh
export HOMEASSISTANT_URL=...
export HOMEASSISTANT_TOKEN=...

uvx git+https://github.com/xeor/homeassistant_python_typer.git hapt.py
ls -lh hapt.py
-rw-r--r--@ 1 xeor  staff   1.5M Dec  3 19:17 hapt.py


uv add git+https://github.com/xeor/homeassistant_python_typer.git
uv run homeassistant-python-typer hapt2.py
ls -lh hapt2.py
-rw-r--r--@ 1 xeor  staff   1.5M Dec  3 19:20 hapt2.py
```

Resolves https://github.com/Ten0/homeassistant_python_typer/issues/2